### PR TITLE
fix blender crash

### DIFF
--- a/archimesh/src/room_maker.py
+++ b/archimesh/src/room_maker.py
@@ -834,10 +834,10 @@ class RoomGeneratorPanel(bpy.types.Panel):
             row.prop(room,'inverse')
 
             row = layout.row()
-            row.prop(room,'ceiling')
-            row.prop(room,'floor')
             if room.wall_num > 1:
                 row.prop(room,'merge')
+                row.prop(room,'ceiling')
+                row.prop(room,'floor')
 
             # Wall number
             row = layout.row()


### PR DESCRIPTION
Little fix: show button floor and ceiling when wall count  > 1
https://github.com/Antonioya/blender/issues/6