### PR TITLE
Room from Draw now works for Grease Pencil Poly lines

### DIFF
--- a/archimesh/src/achm_main_panel.py
+++ b/archimesh/src/achm_main_panel.py
@@ -209,10 +209,6 @@ class AchmPencilAction(bpy.types.Operator):
         mypoints = None
         clearangles = None
 
-        # define error margin 
-        xrange = 0.01
-        yrange = 0.01
-        
         if debugmode is True:
             print("======================================================================")
             print("==                                                                  ==")
@@ -249,11 +245,13 @@ class AchmPencilAction(bpy.types.Operator):
                         if idx == 0:
                             x = point[0]
                             y = point[1]
-                        else:    
-                            if (x - xrange) <= point[0] <= (x + xrange):
+                        else:
+                            abs_x = abs(point[0] - x)
+                            abs_y = abs(point[1] - y)
+
+                            if abs_y > abs_x:
                                 orientation = "V"
-                                
-                            if (y - yrange) <= point[1] <= (y + yrange):
+                            else:
                                 orientation = "H"
                                 
                             if old_orientation == orientation:


### PR DESCRIPTION
The current implementation of the "Room from Draw" only works for "Draw" Grease Pencil mode. I find "Poly" drawing to be more comfortable to use (you have more control). This patch allows for that.

In fact, even the "Draw" mode has some issues helped by this patch.

See file:  http://www.pasteall.org/blend/40497

**Grease Pencil Draw:**
![screen shot 2016-02-05 at 8 28 36 pm](https://cloud.githubusercontent.com/assets/843498/12860968/2a61216c-cc47-11e5-9e9f-eae09391e5d9.png)

**Result before patch**
![screen shot 2016-02-05 at 8 29 15 pm](https://cloud.githubusercontent.com/assets/843498/12860973/3316d34c-cc47-11e5-8523-d17290f0ecff.png)

**Result after patch**
![screen shot 2016-02-05 at 8 28 46 pm](https://cloud.githubusercontent.com/assets/843498/12860979/380da916-cc47-11e5-9a89-c92337d3d2ef.png)
